### PR TITLE
fix: pin CI status badge to default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.npmjs.org/package/package-heuristics-api"><img src="https://badgen.net/npm/v/package-heuristics-api" alt="npm version"/></a>
   <a href="https://www.npmjs.org/package/package-heuristics-api"><img src="https://badgen.net/npm/license/package-heuristics-api" alt="license"/></a>
   <a href="https://www.npmjs.org/package/package-heuristics-api"><img src="https://badgen.net/npm/dt/package-heuristics-api" alt="downloads"/></a>
-  <a href="https://github.com/lirantal/package-heuristics-api/actions?workflow=CI"><img src="https://github.com/lirantal/package-heuristics-api/workflows/CI/badge.svg" alt="build"/></a>
+  <a href="https://github.com/lirantal/package-heuristics-api/actions/workflows/ci.yml"><img src="https://github.com/lirantal/package-heuristics-api/actions/workflows/ci.yml/badge.svg?branch=main" alt="build"/></a>
   <a href="https://codecov.io/gh/lirantal/package-heuristics-api"><img src="https://badgen.net/codecov/c/github/lirantal/package-heuristics-api" alt="codecov"/></a>
   <a href="./SECURITY.md"><img src="https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg" alt="Responsible Disclosure Policy" /></a>
 </p>


### PR DESCRIPTION
The CI status badge in the README currently points to the unpinned workflow URL, which can show the status of any branch (e.g. PR runs) rather than the default branch. Pinning the badge to the repository default branch so it consistently reflects mainline CI.