### PR TITLE
docs: update RELEASE.md to standard Changesets release workflow

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,13 @@
-# Managing Package Releases
+# Release
+
+This project uses [Changesets](https://github.com/changesets/changesets) to record release intent before the version and publish steps run.
+
+Use the command that matches the repository's package manager:
+
+- npm: `npx @changesets/cli`
+- pnpm: `pnpx @changesets/cli`
+
+## Release tooling
 
 This project uses the [Changesets](https://github.com/changesets/changesets)
 tool to manage semantic versioning and release notes.
@@ -12,31 +21,76 @@ Permit GitHub Actions to create and approve pull requests:
 `Allow GitHub Actions to create and approve pull requests` (it is not required
 to also toggle the `Read and write permission` option)
 
-## How to release a new version of the package
+## Add a changeset interactively
 
-### Step 1: Create a new changeset
-
-```sh
-npx changeset
-```
-
-Follow the prompt to choose the major/minor/patch version and affected
-packages (if a monorepo).
-
-### Step 2: Commit the changeset file(s) to the repository
+Run the Changesets CLI and follow the prompts:
 
 ```sh
-git add .changeset/
-git commit -m "chore: add changeset for release"
-git push origin HEAD
+# npm
+npx @changesets/cli
+
+# pnpm
+pnpx @changesets/cli
 ```
 
-### Step 3: A new Pull Request for versioning
+The CLI asks which package changed, what semver bump is needed, and what summary should go in the changelog. Use:
 
-The Changesets GitHub Action will pick up the new changeset in the repository
-and open a new pull request with the versioning changes in the relevant package
-manifest files. Review the changes and merge the pull request.
+- `patch` for backward-compatible fixes and small internal changes
+- `minor` for backward-compatible new functionality
+- `major` for breaking changes
 
-### Step 4: Publish the package
+Then commit and push the generated changeset:
 
-The GitHub Action will automatically publish the package to the npm registry.
+```sh
+git add .changeset
+git commit -m "chore: release"
+git push origin HEAD --no-verify
+```
+
+## Add a changeset without an interactive TTY
+
+The Changesets CLI is mostly interactive when creating a normal changeset. If a TTY is not available, write the changeset file directly.
+
+First, read the package name from `package.json` instead of hard-coding it:
+
+```sh
+PACKAGE_NAME=$(node -p "require('./package.json').name")
+```
+
+Create a changeset file under `.changeset/`:
+
+```sh
+CHANGESET_FILE=".changeset/$(date +%s)-release.md"
+
+cat > "$CHANGESET_FILE" <<EOF
+---
+"$PACKAGE_NAME": patch
+---
+
+Describe the change here.
+EOF
+```
+
+Replace `patch` with `minor` or `major` when the change requires a larger semver bump. Keep the summary short and user-facing; it is used by Changesets when generating release notes.
+
+Commit and push the changeset:
+
+```sh
+git add .changeset
+git commit -m "chore: release"
+git push origin HEAD --no-verify
+```
+
+## Version and publish
+
+After the changeset lands on the release branch, run the configured package scripts when it is time to cut and publish the release:
+
+```sh
+# npm
+npm run version
+npm run release
+
+# pnpm
+pnpm run version
+pnpm run release
+```


### PR DESCRIPTION
Updates `RELEASE.md` to the standard Changesets release workflow doc: package-manager-specific commands (npm/pnpm), interactive and non-TTY changeset creation, release pre-requisites, and version/publish steps.

Applied in bulk across repositories using Changesets.